### PR TITLE
mark set_last_error/translate_message/post_quit_message functions as …

### DIFF
--- a/book_src/loading_opengl/win32.md
+++ b/book_src/loading_opengl/win32.md
@@ -1384,7 +1384,7 @@ And we need to adjust our window procedure:
           println!("Error while getting the userdata ptr for cleanup: {}", e)
         }
       }
-      post_quit_message(0);
+      unsafe { post_quit_message(0) };
     }
     WM_PAINT => match get_window_userdata::<WindowData>(hwnd) {
       Ok(ptr) if !ptr.is_null() => {

--- a/book_src/opening_a_window/win32_cleanup.md
+++ b/book_src/opening_a_window/win32_cleanup.md
@@ -886,7 +886,7 @@ And we'll make this callable as a safe operation,
 /// Sets the thread-local last-error code value.
 ///
 /// See [`SetLastError`](https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-setlasterror)
-pub fn set_last_error(e: Win32Error) {
+pub unsafe fn set_last_error(e: Win32Error) {
   unsafe { SetLastError(e.0) }
 }
 ```
@@ -902,7 +902,7 @@ We'll make it generic over whatever pointer type you want:
 pub unsafe fn set_window_userdata<T>(
   hwnd: HWND, ptr: *mut T,
 ) -> Result<*mut T, Win32Error> {
-  set_last_error(Win32Error(0));
+  unsafe { set_last_error(Win32Error(0)) };
   let out = SetWindowLongPtrW(hwnd, GWLP_USERDATA, ptr as LONG_PTR);
   if out == 0 {
     // if output is 0, it's only a "real" error if the last_error is non-zero
@@ -944,7 +944,7 @@ which is good in this case, because you don't want to forget the type:
 ///
 /// [`GetWindowLongPtrW`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowlongptrw)
 pub unsafe fn get_window_userdata<T>(hwnd: HWND) -> Result<*mut T, Win32Error> {
-  set_last_error(Win32Error(0));
+  unsafe { set_last_error(Win32Error(0)) };
   let out = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
   if out == 0 {
     // if output is 0, it's only a "real" error if the last_error is non-zero
@@ -1012,7 +1012,7 @@ There's nothing that can go wrong, so we just wrap it.
 /// loop eventually gets.
 ///
 /// [`PostQuitMessage`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-postquitmessage)
-pub fn post_quit_message(exit_code: c_int) {
+pub unsafe fn post_quit_message(exit_code: c_int) {
   unsafe { PostQuitMessage(exit_code) }
 }
 ```

--- a/examples/win32_minimal_gl_usage.rs
+++ b/examples/win32_minimal_gl_usage.rs
@@ -143,7 +143,7 @@ fn main() {
         if msg.message == WM_QUIT {
           std::process::exit(msg.wParam as i32);
         }
-        translate_message(&msg);
+        unsafe { translate_message(&msg) };
         unsafe {
           DispatchMessageW(&msg);
         }
@@ -192,7 +192,7 @@ pub unsafe extern "system" fn window_procedure(
           eprintln!("WM_DESTROY> Error getting userdata ptr: {}", e)
         }
       }
-      post_quit_message(0);
+      unsafe { post_quit_message(0) };
     }
     WM_PAINT => match get_window_userdata::<WindowData>(hwnd) {
       Ok(ptr) if !ptr.is_null() => {

--- a/examples/win32_window_cleaned.rs
+++ b/examples/win32_window_cleaned.rs
@@ -33,7 +33,7 @@ fn main() {
         if msg.message == WM_QUIT {
           std::process::exit(msg.wParam as i32);
         }
-        translate_message(&msg);
+        unsafe { translate_message(&msg) };
         unsafe {
           DispatchMessageW(&msg);
         }
@@ -83,7 +83,7 @@ pub unsafe extern "system" fn window_procedure(
           println!("Error while getting the userdata ptr to clean it up: {}", e)
         }
       }
-      post_quit_message(0);
+      unsafe { post_quit_message(0) };
     }
     WM_PAINT => {
       match get_window_userdata::<i32>(hwnd) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn main() {
         if msg.message == WM_QUIT {
           std::process::exit(msg.wParam as i32);
         }
-        translate_message(&msg);
+        unsafe { translate_message(&msg) };
         unsafe {
           DispatchMessageW(&msg);
         }
@@ -197,7 +197,7 @@ pub unsafe extern "system" fn window_procedure(
           eprintln!("WM_DESTROY> Error getting userdata ptr: {}", e)
         }
       }
-      post_quit_message(0);
+      unsafe { post_quit_message(0) };
     }
     WM_PAINT => match get_window_userdata::<WindowData>(hwnd) {
       Ok(ptr) if !ptr.is_null() => {

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -774,7 +774,7 @@ pub fn get_last_error() -> Win32Error {
 /// Sets the thread-local last-error code value.
 ///
 /// See [`SetLastError`](https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-setlasterror)
-pub fn set_last_error(e: Win32Error) {
+pub unsafe fn set_last_error(e: Win32Error) {
   unsafe { SetLastError(e.0) }
 }
 
@@ -931,7 +931,7 @@ pub fn get_any_message() -> Result<MSG, Win32Error> {
 /// * otherwise `false`
 ///
 /// See [`TranslateMessage`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-translatemessage)
-pub fn translate_message(msg: &MSG) -> bool {
+pub unsafe fn translate_message(msg: &MSG) -> bool {
   0 != unsafe { TranslateMessage(msg) }
 }
 
@@ -943,7 +943,7 @@ pub fn translate_message(msg: &MSG) -> bool {
 pub unsafe fn set_window_userdata<T>(
   hwnd: HWND, ptr: *mut T,
 ) -> Result<*mut T, Win32Error> {
-  set_last_error(Win32Error(0));
+  unsafe { set_last_error(Win32Error(0)) };
   let out = SetWindowLongPtrW(hwnd, GWLP_USERDATA, ptr as LONG_PTR);
   if out == 0 {
     // if output is 0, it's only a "real" error if the last_error is non-zero
@@ -964,7 +964,7 @@ pub unsafe fn set_window_userdata<T>(
 ///
 /// [`GetWindowLongPtrW`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowlongptrw)
 pub unsafe fn get_window_userdata<T>(hwnd: HWND) -> Result<*mut T, Win32Error> {
-  set_last_error(Win32Error(0));
+  unsafe { set_last_error(Win32Error(0)) };
   let out = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
   if out == 0 {
     // if output is 0, it's only a "real" error if the last_error is non-zero
@@ -986,7 +986,7 @@ pub unsafe fn get_window_userdata<T>(hwnd: HWND) -> Result<*mut T, Win32Error> {
 /// loop eventually gets.
 ///
 /// [`PostQuitMessage`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-postquitmessage)
-pub fn post_quit_message(exit_code: c_int) {
+pub unsafe fn post_quit_message(exit_code: c_int) {
   unsafe { PostQuitMessage(exit_code) }
 }
 


### PR DESCRIPTION
…unsafe
https://github.com/rust-tutorials/triangle-from-scratch/blob/337446d39f1d907ec9e37e9f4ab78a8fe490276b/src/win32.rs#L777-L779
https://github.com/rust-tutorials/triangle-from-scratch/blob/337446d39f1d907ec9e37e9f4ab78a8fe490276b/src/win32.rs#L934-L936
https://github.com/rust-tutorials/triangle-from-scratch/blob/337446d39f1d907ec9e37e9f4ab78a8fe490276b/src/win32.rs#L989-L991
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.