### PR TITLE
Update lpfnWndProc to use window_procedure earlier & Remove return to help reproduce printed error

### DIFF
--- a/book_src/opening_a_window/win32.md
+++ b/book_src/opening_a_window/win32.md
@@ -1406,6 +1406,15 @@ pub unsafe extern "system" fn window_procedure(
 }
 ```
 
+And update our window class to use window_procedure:
+```rust
+fn main() {
+  // ...
+  wc.lpfnWndProc = Some(window_procedure);
+  // ...
+}
+```
+
 Window looks the same as before,
 but if we fiddle with the brush value we can see it'll draw using other colors.
 Doesn't seem to fix the mouse though.

--- a/book_src/opening_a_window/win32.md
+++ b/book_src/opening_a_window/win32.md
@@ -1406,7 +1406,7 @@ pub unsafe extern "system" fn window_procedure(
 }
 ```
 
-And update our window class to use window_procedure:
+And update our window class to use `window_procedure`:
 ```rust
 fn main() {
   // ...

--- a/book_src/opening_a_window/win32.md
+++ b/book_src/opening_a_window/win32.md
@@ -1458,7 +1458,6 @@ And we check for them in our window procedure:
   match Msg {
     WM_NCCREATE => {
       println!("NC Create");
-      return 1;
     }
     WM_CREATE => println!("Create"),
 ```


### PR DESCRIPTION
 `lpfnWndProc` should be set to use `window_procedure` earlier so that the examples detailing the functionality of the different messages can work properly. 

Reproducing the printed messages after the edited code block requires removal of this return.